### PR TITLE
feat: explicitely display files that are being uploaded

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,8 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use std::{
     borrow::Cow,
-    path::Path,
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -56,6 +57,26 @@ pub fn glob(pattern: &str, target: &str) -> bool {
         Err(_) => return false,
     };
     pat.matches(target)
+}
+
+/// Source: https://internals.rust-lang.org/t/pathbuf-has-set-extension-but-no-add-extension-cannot-cleanly-turn-tar-to-tar-gz/14187/11
+/// Returns a path with a new dotted extension component appended to the end.
+/// Note: does not check if the path is a file or directory; you should do that.
+/// # Example
+/// ```
+/// use pathext::append_ext;
+/// use std::path::PathBuf;
+/// let path = PathBuf::from("foo/bar/baz.txt");
+/// if !path.is_dir() {
+///    assert_eq!(append_ext("app", path), PathBuf::from("foo/bar/baz.txt.app"));
+/// }
+/// ```
+///
+pub fn append_ext(ext: impl AsRef<OsStr>, path: PathBuf) -> PathBuf {
+    let mut os_string: OsString = path.into();
+    os_string.push(".");
+    os_string.push(ext.as_ref());
+    os_string.into()
 }
 
 #[test]


### PR DESCRIPTION
Files that are uploaded to dufs are first written in a temporary files where the extension finished by "dufsupload", before being renamed without the extension once the upload is completely finished.